### PR TITLE
Fixed Paperless and Nextcloud behind reverse-proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ If there is a strong business case for any development of this app, we will cons
 
 ## Development
 
-Set `allow_local_remote_servers` to `true` (boolean) in your config.php.  
 The Paperless server will run on `http://localhost:8000` with username `admin` and password `admin`:
 ```bash
 docker compose up

--- a/lib/Service/ApiService.php
+++ b/lib/Service/ApiService.php
@@ -68,6 +68,9 @@ class ApiService {
 						'contents' => $file->getName(),
 					],
 				],
+				'nextcloud' => [
+					'allow_local_address' => true,
+				],
 			],
 		);
 	}


### PR DESCRIPTION
I fixed this issue in this commit: [Issue #60](https://github.com/nextcloud/integration_paperless/issues/60)