### PR TITLE
fix(files): use @nextcloud/files 4 stable for NC 33 file action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@nextcloud/axios": "^2.4.0",
         "@nextcloud/dialogs": "^4.2.5",
-        "@nextcloud/files": "^4.0.0-rc.0",
+        "@nextcloud/files": "^4.0.0",
         "@nextcloud/initial-state": "^2.1.0",
         "@nextcloud/l10n": "^2.2.0",
         "@nextcloud/router": "^3.0.0",
@@ -2079,9 +2079,9 @@
       }
     },
     "node_modules/@nextcloud/files": {
-      "version": "4.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-4.0.0-rc.0.tgz",
-      "integrity": "sha512-zg/TQH4oQQYlntzkcWokjKIkTX39maiYXceDYrE3OnzCYZv0IKmOH3+pQer58/Z9QfsU8huTnzHblhzVNsJvAA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-4.0.0.tgz",
+      "integrity": "sha512-TmecnZIS+PGWGtRh7RpGEboCT4K6iTbHULUcfR6hs3eEzjDVsCc1Ldf8popGY/70lbpdlfYle8xbXnPIo3qaXA==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.5.3",
@@ -2093,7 +2093,7 @@
         "@nextcloud/sharing": "^0.3.0",
         "is-svg": "^6.1.0",
         "typescript-event-target": "^1.1.2",
-        "webdav": "^5.8.0"
+        "webdav": "^5.9.0"
       },
       "engines": {
         "node": "^24.0.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@nextcloud/axios": "^2.4.0",
     "@nextcloud/dialogs": "^4.2.5",
-    "@nextcloud/files": "^4.0.0-rc.0",
+    "@nextcloud/files": "^4.0.0",
     "@nextcloud/initial-state": "^2.1.0",
     "@nextcloud/l10n": "^2.2.0",
     "@nextcloud/router": "^3.0.0",

--- a/src/file_action.js
+++ b/src/file_action.js
@@ -1,4 +1,4 @@
-import { registerFileAction, FileAction } from '@nextcloud/files'
+import { registerFileAction } from '@nextcloud/files'
 import PaperlessLogo from '../img/app.svg'
 import { translate as t } from '@nextcloud/l10n'
 import axios from '@nextcloud/axios'
@@ -14,19 +14,17 @@ async function uploadFile(node) {
 	}
 }
 
-registerFileAction(
-	new FileAction({
-		id: 'integration_paperless-upload-file',
-		displayName: () => {
-			return t('integration_paperless', 'Upload to Paperless')
-		},
-		iconSvgInline: () => PaperlessLogo,
-		enabled: () => true,
-		exec: async (context) => {
-			return await uploadFile(context.nodes[0])
-		},
-		execBatch: async (context) => {
-			return Promise.all(context.nodes.map(uploadFile))
-		},
-	}),
-)
+registerFileAction({
+	id: 'integration_paperless-upload-file',
+	displayName: () => {
+		return t('integration_paperless', 'Upload to Paperless')
+	},
+	iconSvgInline: () => PaperlessLogo,
+	enabled: () => true,
+	exec: async (context) => {
+		return await uploadFile(context.nodes[0])
+	},
+	execBatch: async (context) => {
+		return Promise.all(context.nodes.map(uploadFile))
+	},
+})


### PR DESCRIPTION
## Problem

On **Nextcloud 33**, the Files app does not show **Upload to Paperless**, even when the user has URL and token configured. Server-side `isComplete()` is true and the init script is registered.

## Cause

1. The app was built against `@nextcloud/files` **4.0.0-rc.0**. Nextcloud 33 **scopes** file actions; RC-based registrations are ignored ([nextcloud-files#1494](https://github.com/nextcloud-libraries/nextcloud-files/issues/1494)).

2. Stable `@nextcloud/files` **4.0.0** no longer exports the **`FileAction`** class; `registerFileAction` expects a **plain object**.

## Changes

- Bump `@nextcloud/files` to `^4.0.0` and refresh `package-lock.json`.
- Use a plain object in `src/file_action.js`.

Maintainers: run `npm ci && npm run build` before release (`js/` is gitignored).

Fixes #124
